### PR TITLE
Add an intermediate `PeriodicStructuredMesh` class to separate the `origin` attribute from `StructuredMesh`

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -75,6 +75,12 @@ public:
 
   // Methods
 
+  //! Update a position to the local coordinates of the mesh
+  virtual void to_local_coords(Position& r) const {};
+
+  //! Return a position in the local coordinates of the mesh
+  virtual Position local_coords(const Position& r) const { return r; };
+
   //! Determine which bins were crossed by a particle
   //
   //! \param[in] r0 Previous position of the particle
@@ -160,7 +166,7 @@ public:
     }
   };
 
-  int get_bin(Position r) const override;
+  virtual int get_bin(Position r) const;
 
   int n_bins() const override;
 
@@ -241,9 +247,25 @@ public:
   xt::xtensor<double, 1> lower_left_;  //!< Lower-left coordinates of mesh
   xt::xtensor<double, 1> upper_right_; //!< Upper-right coordinates of mesh
   std::array<int, 3> shape_; //!< Number of mesh elements in each dimension
-  Position origin_ {0.0, 0.0, 0.0};
 
 protected:
+};
+
+class PeriodicStructuredMesh : public StructuredMesh {
+
+public:
+  PeriodicStructuredMesh() = default;
+  PeriodicStructuredMesh(pugi::xml_node node) : StructuredMesh {node} {};
+
+  void to_local_coords(Position& r) const override { r -= origin_; };
+
+  Position local_coords(const Position& r) const override
+  {
+    return r - origin_;
+  };
+
+  // Data members
+  Position origin_ {0.0, 0.0, 0.0};
 };
 
 //==============================================================================
@@ -336,7 +358,7 @@ public:
   int set_grid();
 };
 
-class CylindricalMesh : public StructuredMesh {
+class CylindricalMesh : public PeriodicStructuredMesh {
 public:
   // Constructors
   CylindricalMesh() = default;
@@ -390,7 +412,7 @@ private:
   }
 };
 
-class SphericalMesh : public StructuredMesh {
+class SphericalMesh : public PeriodicStructuredMesh {
 public:
   // Constructors
   SphericalMesh() = default;

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -76,7 +76,7 @@ public:
   // Methods
 
   //! Update a position to the local coordinates of the mesh
-  virtual void to_local_coords(Position& r) const {};
+  virtual void local_coords(Position& r) const {};
 
   //! Return a position in the local coordinates of the mesh
   virtual Position local_coords(const Position& r) const { return r; };
@@ -257,7 +257,7 @@ public:
   PeriodicStructuredMesh() = default;
   PeriodicStructuredMesh(pugi::xml_node node) : StructuredMesh {node} {};
 
-  void to_local_coords(Position& r) const override { r -= origin_; };
+  void local_coords(Position& r) const override { r -= origin_; };
 
   Position local_coords(const Position& r) const override
   {
@@ -265,7 +265,7 @@ public:
   };
 
   // Data members
-  Position origin_ {0.0, 0.0, 0.0};
+  Position origin_ {0.0, 0.0, 0.0}; //!< Origin of the mesh
 };
 
 //==============================================================================

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -446,8 +446,8 @@ void StructuredMesh::raytrace_mesh(
 
   // translate start and end positions,
   // this needs to come after the get_indices call because it does its own translation
-  r0 -= origin_;
-  r1 -= origin_;
+  to_local_coords(r0);
+  to_local_coords(r1);
 
   // Calculate initial distances to next surfaces in all three dimensions
   std::array<MeshDistance, 3> distances;
@@ -952,7 +952,8 @@ void RectilinearMesh::to_hdf5(hid_t group) const
 // CylindricalMesh implementation
 //==============================================================================
 
-CylindricalMesh::CylindricalMesh(pugi::xml_node node) : StructuredMesh {node}
+CylindricalMesh::CylindricalMesh(pugi::xml_node node)
+  : PeriodicStructuredMesh {node}
 {
   n_dimension_ = 3;
 
@@ -976,7 +977,7 @@ std::string CylindricalMesh::get_mesh_type() const
 StructuredMesh::MeshIndex CylindricalMesh::get_indices(
   Position r, bool& in_mesh) const
 {
-  r -= origin_;
+  to_local_coords(r);
 
   Position mapped_r;
   mapped_r[0] = std::hypot(r.x, r.y);
@@ -1189,7 +1190,8 @@ void CylindricalMesh::to_hdf5(hid_t group) const
 // SphericalMesh implementation
 //==============================================================================
 
-SphericalMesh::SphericalMesh(pugi::xml_node node) : StructuredMesh {node}
+SphericalMesh::SphericalMesh(pugi::xml_node node)
+  : PeriodicStructuredMesh {node}
 {
   n_dimension_ = 3;
 
@@ -1213,7 +1215,7 @@ std::string SphericalMesh::get_mesh_type() const
 StructuredMesh::MeshIndex SphericalMesh::get_indices(
   Position r, bool& in_mesh) const
 {
-  r -= origin_;
+  to_local_coords(r);
 
   Position mapped_r;
   mapped_r[0] = r.norm();

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -446,8 +446,8 @@ void StructuredMesh::raytrace_mesh(
 
   // translate start and end positions,
   // this needs to come after the get_indices call because it does its own translation
-  to_local_coords(r0);
-  to_local_coords(r1);
+  local_coords(r0);
+  local_coords(r1);
 
   // Calculate initial distances to next surfaces in all three dimensions
   std::array<MeshDistance, 3> distances;
@@ -977,7 +977,7 @@ std::string CylindricalMesh::get_mesh_type() const
 StructuredMesh::MeshIndex CylindricalMesh::get_indices(
   Position r, bool& in_mesh) const
 {
-  to_local_coords(r);
+  local_coords(r);
 
   Position mapped_r;
   mapped_r[0] = std::hypot(r.x, r.y);
@@ -1215,7 +1215,7 @@ std::string SphericalMesh::get_mesh_type() const
 StructuredMesh::MeshIndex SphericalMesh::get_indices(
   Position r, bool& in_mesh) const
 {
-  to_local_coords(r);
+  local_coords(r);
 
   Position mapped_r;
   mapped_r[0] = r.norm();


### PR DESCRIPTION
Hiya @RemDelaporteMathurin,

This should take care of [this comment](https://github.com/openmc-dev/openmc/pull/2256#discussion_r1122346534) on https://github.com/openmc-dev/openmc/pull/2256/. 

It adds an intermediate class between the other structured mesh types and a general function for moving a position into the local coordinates of a mesh. Right now it does nothing for the `RegularMesh` and `RectilinearMesh` classes, but will adjust a position by subtracting `origin_` for the `CylindricalMesh` and `SphericalMesh` classes. This additional function allows us to make a generic call in `StructuredMesh::raytrace_mesh` to adjust particle coordinates regardless of the mesh type.